### PR TITLE
 Added CFF type2 composite glyphs support

### DIFF
--- a/src/ttf/table/cff/parseCFFGlyph.js
+++ b/src/ttf/table/cff/parseCFFGlyph.js
@@ -22,6 +22,7 @@ define(
             var contours = [];
             var contour = [];
             var stack = [];
+            var glyfs = [];
             var nStems = 0;
             var haveWidth = false;
             var width = font.defaultWidthX;
@@ -249,9 +250,20 @@ define(
                             }
                             break;
                         case 14: // endchar
-                            if (stack.length > 0 && !haveWidth) {
+                            if (stack.length == 1 && !haveWidth) {
                                 width = stack.shift() + font.nominalWidthX;
                                 haveWidth = true;
+                            }
+                            else if (stack.length == 4) {
+                              glyfs[0] = {glyphIndex: font.charset.indexOf(font.encoding[stack.pop()])};
+                              glyfs[1] = {glyphIndex: font.charset.indexOf(font.encoding[stack.pop()]), transform: {a:1, b:0, c:0, d:1, f: stack.pop(), e:stack.pop()};
+                            }
+                            else if (stack.length == 5) {
+                              if (!haveWidth)
+                                width = stack.shift() + font.nominalWidthX;
+                              haveWidth = true;
+                              glyfs[0] = {glyphIndex: font.charset.indexOf(font.encoding[stack.pop()])};
+                              glyfs[1] = {glyphIndex: font.charset.indexOf(font.encoding[stack.pop()]), transform: {a:1, b:0, c:0, d:1, f: stack.pop(), e:stack.pop()};
                             }
 
                             if (open) {
@@ -455,6 +467,8 @@ define(
 
                 advanceWidth: width
             };
+            if (glyfs.length)
+              glyf.glyfs = glyfs;
             return glyf;
         }
 

--- a/src/ttf/util/checkSum.js
+++ b/src/ttf/util/checkSum.js
@@ -8,7 +8,7 @@ define(
 
         function checkSumArrayBuffer(buffer, offset, length) {
             offset = offset || 0;
-            length = length || buffer.byteLength;
+            length = length == undefined ? buffer.byteLength : length;
 
             if (offset + length > buffer.byteLength) {
                 throw new Error('check sum out of bound');

--- a/src/ttf/woff2ttf.js
+++ b/src/ttf/woff2ttf.js
@@ -26,7 +26,7 @@ define(
             var signature = reader.readUint32(0);
             var flavor = reader.readUint32(4);
 
-            if (signature !== 0x774F4646 || flavor !== 0x10000) {
+            if (signature !== 0x774F4646 || (flavor !== 0x10000 && flavor !== 0x4f54544f)) {
                 reader.dispose();
                 error.raise(10102);
             }
@@ -76,7 +76,7 @@ define(
             var searchRange = Math.pow(2, entrySelector) * 16;
             var rangeShift = numTables * 16 - searchRange;
 
-            writer.writeFixed(1);
+            writer.writeUint32(flavor);
             writer.writeUint16(numTables);
             writer.writeUint16(searchRange);
             writer.writeUint16(entrySelector);


### PR DESCRIPTION
Hi everyone.
Please find two independant things in this PR:
- CFF type 2 composite glyphs added support (see endchar in Appendix C of
[Adobe Technical Note #5177](https://github.com/kekee000/fonteditor-core/files/2533818/5177.Type2.pdf))

- zero length fonts checksum crash fix (weird thing, I admit, but I faced this problem)

Thanks for the great job on fonteditor.
