### PR TITLE
Fix for glyphs with no contour and no compound (i.e whitespace)

### DIFF
--- a/src/ttf/table/OS2.js
+++ b/src/ttf/table/OS2.js
@@ -198,33 +198,30 @@ export default table.create(
                 }
 
                 // 统计边界信息
-                if (glyf.compound || glyf.contours && glyf.contours.length) {
-
-                    if (glyf.xMin < xMin) {
-                        xMin = glyf.xMin;
-                    }
-
-                    if (glyf.yMin < yMin) {
-                        yMin = glyf.yMin;
-                    }
-
-                    if (glyf.xMax > xMax) {
-                        xMax = glyf.xMax;
-                    }
-
-                    if (glyf.yMax > yMax) {
-                        yMax = glyf.yMax;
-                    }
-
-                    advanceWidthMax = Math.max(advanceWidthMax, glyf.advanceWidth);
-                    minLeftSideBearing = Math.min(minLeftSideBearing, glyf.leftSideBearing);
-                    minRightSideBearing = Math.min(minRightSideBearing, glyf.advanceWidth - glyf.xMax);
-                    xMaxExtent = Math.max(xMaxExtent, glyf.xMax);
-
-                    xAvgCharWidth += glyf.advanceWidth;
-
-                    glyfNotEmpty++;
+                if (glyf.xMin < xMin) {
+                    xMin = glyf.xMin;
                 }
+
+                if (glyf.yMin < yMin) {
+                    yMin = glyf.yMin;
+                }
+
+                if (glyf.xMax > xMax) {
+                    xMax = glyf.xMax;
+                }
+
+                if (glyf.yMax > yMax) {
+                    yMax = glyf.yMax;
+                }
+
+                advanceWidthMax = Math.max(advanceWidthMax, glyf.advanceWidth);
+                minLeftSideBearing = Math.min(minLeftSideBearing, glyf.leftSideBearing);
+                minRightSideBearing = Math.min(minRightSideBearing, glyf.advanceWidth - glyf.xMax);
+                xMaxExtent = Math.max(xMaxExtent, glyf.xMax);
+
+                xAvgCharWidth += glyf.advanceWidth;
+
+                glyfNotEmpty++;
 
                 let unicodes = glyf.unicode;
 

--- a/src/ttf/table/glyf/sizeof.js
+++ b/src/ttf/table/glyf/sizeof.js
@@ -15,20 +15,16 @@ import glyFlag from '../../enum/glyFlag';
  */
 function sizeofSimple(glyf, glyfSupport, hinting) {
 
-    if (!glyf.contours || 0 === glyf.contours.length) {
-        return 0;
-    }
-
     // fixed header + endPtsOfContours
     let result = 12
-        + glyf.contours.length * 2
-        + glyfSupport.flags.length;
+        + (glyf.contours || []).length * 2
+        + (glyfSupport.flags || []).length;
 
-    glyfSupport.xCoord.forEach(function (x) {
+    (glyfSupport.xCoord || []).forEach(function (x) {
         result += 0 <= x && x <= 0xFF ? 1 : 2;
     });
 
-    glyfSupport.yCoord.forEach(function (y) {
+    (glyfSupport.yCoord || []).forEach(function (y) {
         result += 0 <= y && y <= 0xFF ? 1 : 2;
     });
 

--- a/src/ttf/table/glyf/write.js
+++ b/src/ttf/table/glyf/write.js
@@ -17,13 +17,8 @@ export default function write(writer, ttf) {
     let hinting = ttf.writeOptions ? ttf.writeOptions.hinting : false;
     ttf.glyf.forEach(function (glyf, index) {
 
-        // 非复合图元没有轮廓则不写
-        if (!glyf.compound && (!glyf.contours || 0 === glyf.contours.length)) {
-            return;
-        }
-
         // header
-        writer.writeInt16(glyf.compound ? -1 : glyf.contours.length);
+        writer.writeInt16(glyf.compound ? -1 : (glyf.contours || []).length);
         writer.writeInt16(glyf.xMin);
         writer.writeInt16(glyf.yMin);
         writer.writeInt16(glyf.xMax);
@@ -112,7 +107,7 @@ export default function write(writer, ttf) {
         else {
 
             let endPtsOfContours = -1;
-            glyf.contours.forEach(function (contour) {
+            (glyf.contours || []).forEach(function (contour) {
                 endPtsOfContours += contour.length;
                 writer.writeUint16(endPtsOfContours);
             });
@@ -131,12 +126,12 @@ export default function write(writer, ttf) {
 
 
             // 获取暂存中的flags
-            flags = ttf.support.glyf[index].flags;
+            flags = ttf.support.glyf[index].flags || [];
             for (i = 0, l = flags.length; i < l; i++) {
                 writer.writeUint8(flags[i]);
             }
 
-            let xCoord = ttf.support.glyf[index].xCoord;
+            let xCoord = ttf.support.glyf[index].xCoord || [];
             for (i = 0, l = xCoord.length; i < l; i++) {
                 if (0 <= xCoord[i] && xCoord[i] <= 0xFF) {
                     writer.writeUint8(xCoord[i]);
@@ -146,7 +141,7 @@ export default function write(writer, ttf) {
                 }
             }
 
-            let yCoord = ttf.support.glyf[index].yCoord;
+            let yCoord = ttf.support.glyf[index].yCoord || [];
             for (i = 0, l = yCoord.length; i < l; i++) {
                 if (0 <= yCoord[i] && yCoord[i] <= 0xFF) {
                     writer.writeUint8(yCoord[i]);


### PR DESCRIPTION
Hello.
I had a rejection from font sanitizer in browsers on some fonts (for empty glyph table reasons) and found that they had only .notdef and whitespace glyphs (well, you may think this is weird, and it is, but these fonts are extracted from PDF, so, only used glyphs are in it).
According to the spec, a glyph with no compound and no contour is allowed, and, it is reasonable to think that the white space character shall be described.

So, here is a fix proposal.