### PR TITLE
Fix handling of unicode code points > 0xffff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - '0.10'
   - '0.12'
 install:
+  - npm cache clean -f
   - npm install
   - npm run build
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
+install:
+  - npm install
+  - npm run build
+script:
+  - npm test

--- a/src/common/string.js
+++ b/src/common/string.js
@@ -21,7 +21,7 @@ export default {
 
         // 处理转义的中文和实体字符
         return str.replace(/&#([\d]+);/g, function ($0, $1) {
-            return String.fromCharCode(parseInt($1, 10));
+            return String.fromCodePoint(parseInt($1, 10));
         });
     },
 

--- a/src/ttf/svg2ttfobject.js
+++ b/src/ttf/svg2ttfobject.js
@@ -272,10 +272,6 @@ function parseGlyf(xmlDoc, ttf) {
 
     if (glyfNodes.length) {
 
-        // map unicode
-        let unicodeMap = function (u) {
-            return u.charCodeAt(0);
-        };
 
         for (let i = 0, l = glyfNodes.length; i < l; i++) {
 
@@ -289,7 +285,14 @@ function parseGlyf(xmlDoc, ttf) {
             }
 
             if ((unicode = node.getAttribute('unicode'))) {
-                glyf.unicode = unicode.split('').map(unicodeMap);
+                glyf.unicode = []
+                let nextIndex =0;
+                for(let ui=0; ui < unicode.length; ui++) {
+                    let ucp = unicode.codePointAt(ui)
+                    glyf.unicode.push(ucp)
+                    ui = ucp > 0xffff ? ui +1 : ui
+                }
+
             }
 
             if ((d = node.getAttribute('d'))) {

--- a/src/ttf/svg2ttfobject.js
+++ b/src/ttf/svg2ttfobject.js
@@ -285,20 +285,27 @@ function parseGlyf(xmlDoc, ttf) {
             }
 
             if ((unicode = node.getAttribute('unicode'))) {
-                glyf.unicode = []
+                let nextUnicode = []
                 let nextIndex =0;
+                let totalCodePoints = 0;
+                let dupe = false
                 for(let ui=0; ui < unicode.length; ui++) {
                     let ucp = unicode.codePointAt(ui)
-                    glyf.unicode.push(ucp)
+                    nextUnicode.push(ucp)
                     ui = ucp > 0xffff ? ui +1 : ui
+                    totalCodePoints = totalCodePoints + 1;
                 }
+                if(totalCodePoints == 1) { //TTF can't handle ligatures
+                  glyf.unicode = nextUnicode
 
+                  if ((d = node.getAttribute('d'))) {
+                    glyf.contours = path2contours(d);
+                  }
+                  ttf.glyf.push(glyf);
+
+                }
             }
 
-            if ((d = node.getAttribute('d'))) {
-                glyf.contours = path2contours(d);
-            }
-            ttf.glyf.push(glyf);
         }
     }
 

--- a/src/ttf/ttf.js
+++ b/src/ttf/ttf.js
@@ -192,7 +192,7 @@ export default class TTF {
      * @return {?number} 返回glyf索引号
      */
     getGlyfIndexByCode(c) {
-        let charCode = typeof c === 'number' ? c : c.charCodeAt(0);
+        let charCode = typeof c === 'number' ? c : c.codePointAt(0);
         let glyfIndex = this.ttf.cmap[charCode] || -1;
         return glyfIndex;
     }

--- a/src/ttf/util/string.js
+++ b/src/ttf/util/string.js
@@ -94,7 +94,11 @@ export default {
                 byteArray.push(str.charCodeAt(i));
             }
             else {
-                let h = encodeURIComponent(str.charAt(i)).slice(1).split('%');
+                let codePoint = str.codePointAt(i)
+                if(codePoint > 0xffff) {
+                  i = i + 1;
+                }
+                let h = encodeURIComponent(String.fromCodePoint(codePoint)).slice(1).split('%');
                 for (let j = 0; j < h.length; j++) {
                     byteArray.push(parseInt(h[j], 16));
                 }

--- a/test/spec/ttf/ttf2svg.spec.js
+++ b/test/spec/ttf/ttf2svg.spec.js
@@ -30,8 +30,8 @@ describe('ttf 转 svg', function () {
         assert.equal(ttf.hhea.ascent, fontObject.hhea.ascent);
         assert.equal(ttf.hhea.descent, fontObject.hhea.descent);
 
-        assert.equal(ttf.glyf.length, 14);
-        assert.equal(ttf.glyf[3].contours.length, 3);
-        assert.equal(ttf.glyf[3].unicode[0], 57357);
+        assert.equal(ttf.glyf.length, 13); // original file has 14 glyphs + .notdef, but 2 are compound so expected is 15 - 2 = 13
+        assert.equal(ttf.glyf[2].contours.length, 3);
+        assert.equal(ttf.glyf[2].unicode[0], 57357);
     });
 });


### PR DESCRIPTION
This fixes several cases where unicode code points > 0xffff are not handled properly because javascript uses a fixed 16bit representation of all characters, rather than unicode variable width up to 32bit.

This fixes kekee000/fonteditor-core#37 