### PR TITLE
Fix Travis CI build by using current version of Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - '0.10'
-  - '0.12'
+  - "node"
 install:
   - npm cache clean -f
   - npm install


### PR DESCRIPTION
Currently Travis CI is set to use Node versions 0.10 and 0.12. Note the first digit. Current common versions are 10.x and 12.x. We're testing with ancient versions of node, from the time that dinosaurs roamed the earth. Let's test with the latest stable Node, represented by "node" in .travis.yml, so that if we just ignore Travis configuration for awhile as the development of Node marches on, this should still work and be relevant.