### PR TITLE
fix: incorrect TypeScript definition for OptimizeResult

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -309,13 +309,13 @@ export namespace FontEditor {
          * result
          *
          * - true optimize success
-         * - {repeatList} repeat glyf codepoints
+         * - {repeat} repeat glyf codepoints
          */
         result: true | {
             /**
              * repeat glyf codepoints
              */
-            repeatList: number[];
+            repeat: number[];
         };
 
     };


### PR DESCRIPTION
When converting my codebase to TypeScript, I noticed that the `OptimizeResult` type contains a property named `repeatList`, but in the implementation the property is named `repeat`.

Thanks!